### PR TITLE
Faster buffered writing in SC16IS740Base

### DIFF
--- a/src/SC16IS740RK.cpp
+++ b/src/SC16IS740RK.cpp
@@ -101,8 +101,8 @@ size_t SC16IS740Base::write(const uint8_t *buffer, size_t size) {
 
 	while(size > 0 && !done) {
 		size_t count = size;
-		if (count > writeInternalMax()) {
-			count = writeInternalMax();
+		if (count > writeInternalMax()/2) {
+			count = writeInternalMax()/2;
 		}
 
 		if (writeBlocksWhenFull) {
@@ -111,7 +111,6 @@ size_t SC16IS740Base::write(const uint8_t *buffer, size_t size) {
 				if (count <= (size_t) avail) {
 					break;
 				}
-				delay(1);
 			}
 		}
 		else {


### PR DESCRIPTION
- Only write a maximum of half of the max available bytes at a time to improve writing frequency and decrease pauses between larger byte chunks


I am currently using SC16IS740Base in one of my IoT projects. I noticed that writing speeds increased when utilizing a buffered array to write to the SPI line compared to writing byte by byte. However even though my SPI line supports a max of 64B per writing message, I think there could be further optimization to increase writing speeds further.

I am suggesting that the count should be set to half of the writeInternalMax and removing the delay in the while(true). This is because when waiting for the maximum available bytes before writing, I have experienced delays of 180 microseconds with longer writing periods of 10-20 minutes this delay has been seen up to 1ms. However by writing half of the byte max, there should always be enough space available for writing and there would be no delay between writing chunks of bytes. This change has resulted in improved writing speeds in my IoT project and thought it would be helpful for others and the project.