### PR TITLE
Fix peekByte casting to uint8_t

### DIFF
--- a/src/SC16IS740RK.cpp
+++ b/src/SC16IS740RK.cpp
@@ -69,7 +69,10 @@ int SC16IS740Base::read() {
 
 int SC16IS740Base::peek() {
 	if (!hasPeek) {
-		peekByte = read();
+		int readResult = read();
+		if (readResult == -1)
+			return readResult;
+		peekByte = (uint8_t) readResult;
 		hasPeek = true;
 	}
 	return peekByte;


### PR DESCRIPTION
- Changed peekByte to an int8_t
- Change hasPeek flag only if peekByte isnt -1

Previously peekByte was a uint8 so any -1 value would get casted to a 255, and the read function would utilize this peek byte if the user ever peeked. Thus resulting in an extra 0xFF byte appearing at the beginning of every read.

Fixed peekByte to be an int8 and handled casting only when a byte is actually available (ie not -1)