### PR TITLE
Added support for multi-channel serial port IC's like the SC16IS752 and RS485

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ One difficulty is that the chip is only available in surface mount packages such
 
 You can connect up to 4 separate SC16IS740 chips to the single I2C interface on D0 and D1 by I2C.
 
+You can connect a SC16IS752 or SC16IS762 chip to have multiple serial ports with only one chip.
+
 The number of separate chips for SPI is limited to the number of available GPIO pins, as each one must have a unique CS pin, but they can share a single SPI bus.
 
 When using a 1.8432 MHz oscillator it supports baud rate from 50 to 115200.
@@ -80,7 +82,7 @@ The SC16IS740 library derives from Stream so the standard Arduino features like 
 
 ## API
 
-#### `public  `[`SC16IS740`](#class_s_c16_i_s740_1a48a15f05e738b52cca9549046b6360c5)`(TwoWire & wire,int addr,int intPin)` 
+#### `public  `[`SC16IS740`](#class_s_c16_i_s740_1a48a15f05e738b52cca9549046b6360c5)`(TwoWire & wire,int addr,int intPin, int aChannel)` 
 
 Construct the UART object. Typically done as a global variable.
 
@@ -89,7 +91,9 @@ Construct the UART object. Typically done as a global variable.
 
 * `addr` The address you've set using the A0 and A1 pins, 0-3. This will be converted to the appropriate I2C address. Or you can directly specify the actual I2C address 0-127.
 
-* `intPin` The interrupt pin (-1 = not used). Note: interrupts are not currently supported.
+* `intPin` The interrupt pin (-1 = not used). Note: interrupts are not currently supported. Defaults to -1.
+
+* 'aChannel' The channel in a multi-channel serial port ic. Can be 0 or 1 for a SC16IS752 for example. Defaults to 0.
 
 
 #### `public inline `[`SC16IS740`](#class_s_c16_i_s740)` & `[`withOscillatorHz`](#class_s_c16_i_s740_1a2bade8e74f73cd4175b295d7f6e620ce)`(int value)` 
@@ -198,6 +202,12 @@ SC16IS740SPI extSerial(SPI1, D5);
 ```
 
 ## Version History
+
+### 0.0.8 (2022-06-28)
+
+- Added auto RTS driving for RS485 setup option.
+- Added support for multi-channel serial IC's like the SC16IS752.
+- Fixed DMA only supporting RAM transfer check for platform other than mesh.
 
 ### 0.0.7 (2020-05-04)
 

--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
 # Fill in information about your library then remove # from the start of lines
 # https://docs.particle.io/guide/tools-and-features/libraries/#library-properties-fields
 name=SC16IS740RK
-version=0.0.7
+version=0.0.8
 author=rickkas7@rickkas7.com
 license=MIT
 sentence=Particle driver for SC16IS740 UART

--- a/src/SC16IS740RK.cpp
+++ b/src/SC16IS740RK.cpp
@@ -327,8 +327,9 @@ bool SC16IS740SPI::readInternal(uint8_t *buffer, size_t size) {
 	beginTransaction();
 
 	spi.transfer(0x80 | RHR_THR_REG << 3);
-#if HAL_PLATFORM_MESH
-	// On mesh platforms, the DMA spi.transfer is causing a SOS fault. Disable for now.
+#if HAL_PLATFORM_SPI_DMA_SOURCE_RAM_ONLY
+	//On NRF52840 platforms with older device os < 3.0.0, the DMA ROM spi.transfer is causing a SOS fault. Disable for now.
+	//An optimization could be to check if a transfer is from ROM or RAM.
 	for(size_t ii = 0; ii < size; ii++) {
 		buffer[ii] = spi.transfer(0);
 	}
@@ -345,9 +346,10 @@ bool SC16IS740SPI::readInternal(uint8_t *buffer, size_t size) {
 bool SC16IS740SPI::writeInternal(const uint8_t *buffer, size_t size) {
 	beginTransaction();
 
-	spi.transfer(RHR_THR_REG << 3);
-#if HAL_PLATFORM_MESH
-	// On mesh platforms, the DMA spi.transfer is causing a SOS fault. Disable for now.
+	spi.transfer(RHR_THR_REG << 3 | channel);
+#if HAL_PLATFORM_SPI_DMA_SOURCE_RAM_ONLY
+	//On NRF52840 platforms with older device os, the DMA ROM spi.transfer is causing a SOS fault. Disable for now.
+	//An optimization could be to check if a transfer is from ROM or RAM.	
 	for(size_t ii = 0; ii < size; ii++) {
 		spi.transfer(buffer[ii]);
 	}

--- a/src/SC16IS740RK.cpp
+++ b/src/SC16IS740RK.cpp
@@ -51,6 +51,14 @@ int SC16IS740Base::availableForWrite() {
 	return readRegister(TXLVL_REG);
 }
 
+SC16IS740Base& SC16IS740Base::withAutoRS485(void){
+	uint8_t reg = readRegister(EFCR_REG);
+	reg |= (1<<5);
+	reg |= (1<<4);
+	writeRegister(EFCR_REG, reg);
+	return *this;
+}
+
 
 int SC16IS740Base::read() {
 	if (hasPeek) {

--- a/src/SC16IS740RK.h
+++ b/src/SC16IS740RK.h
@@ -240,6 +240,7 @@ protected:
 	bool hasPeek = false;
 	uint8_t peekByte = 0;
 	bool writeBlocksWhenFull = true;
+	uint8_t channel;
 };
 
 class SC16IS740 : public SC16IS740Base {
@@ -251,8 +252,10 @@ public:
 	 *
 	 * @param addr The address you've set using the A0 and A1 pins, 0-3. This will be converted to the
 	 * appropriate I2C address. Or you can directly specify the actual I2C address 0-127.
-	 */
-	SC16IS740(TwoWire &wire, int addr);
+	 * 
+	 * @param channel The channel (0,1) of a multi serial chip like the SC16IS752.
+	 */	
+	SC16IS740(TwoWire &wire, int addr, int channel = 0);	
 
 	/**
 	 * @brief Destructor. You typically don't delete one of these as it's normally a global variable.
@@ -324,8 +327,10 @@ public:
 	 *
 	 * @param intPin The pin to use for interrupts from the SC16IS740. Not currently used.
 	 * If not using interrupts, omit this parameter or pass -1.
+	 * 
+	 * @param channel The channel (0,1) of a multi-serial chip like the SC16IS752.
 	 */
-	SC16IS740SPI(SPIClass &spi, int cs, int intPin = -1);
+	SC16IS740SPI(SPIClass &spi, int cs, int intPin = -1, int aChannel = 0);
 
 #ifdef SYSTEM_VERSION_v151RC1
 	// In 1.5.0-rc.1, SPI interfaces are handled differently. You can still pass in SPI, SPI1, etc.
@@ -382,6 +387,7 @@ public:
 	 * @param delayus Amount of time in microseconds to delay after changing SPI settings to allow the bus to settle.
 	 */
 	inline SC16IS740SPI &withSharedBus(unsigned long delayus) { sharedBus = true; sharedBusDelay = delayus; return *this;};
+
 
 protected:
 	/**

--- a/src/SC16IS740RK.h
+++ b/src/SC16IS740RK.h
@@ -20,6 +20,14 @@ public:
 	inline SC16IS740Base &withOscillatorHz(int value) { oscillatorHz = value; return *this; };
 
 	/**
+	 * @brief Sets auto RS485
+	 *
+	 * In Auto RS485 mode, the pin RTS is automatically driven while sending data.
+	 * Run After calling begin().
+	 */
+	SC16IS740Base& withAutoRS485(void);
+
+	/**
 	 * @brief Set up the chip. You must do this before reading or writing.
 	 *
 	 * @param baudRate the baud rate (see below)


### PR DESCRIPTION
I added support for multi-channel IC's without breaking the standard syntax. The overhead for a single channel IC is low enough that it would not pose problems.